### PR TITLE
Issue #SB-17539 feat: Implementation of assessment editor

### DIFF
--- a/app/scripts/contenteditor/manager/stage-manager.js
+++ b/app/scripts/contenteditor/manager/stage-manager.js
@@ -279,7 +279,7 @@ org.ekstep.contenteditor.stageManager = new (Class.extend({
 		instance.manifestGenerator(content)
 
 		/* istanbul ignore else  */
-		if (_.includes(org.ekstep.contenteditor.config.assessContentType, this._getContentType())) {
+		if (this._isAssessment()) {
 			content = this._appendPluginStage(content, this.summaryTemplate);
 		} 
 		ecEditor._.each(content.theme['plugin-manifest'].plugin, function (p){
@@ -360,8 +360,9 @@ org.ekstep.contenteditor.stageManager = new (Class.extend({
 		org.ekstep.contenteditor.api.ngSafeApply(org.ekstep.contenteditor.api.getAngularScope())
 		org.ekstep.contenteditor.stageManager.contentLoading = true
 		org.ekstep.pluginframework.eventManager.enableEvents = false
+		
 		/* istanbul ignore else  */
-		if (_.includes(org.ekstep.contenteditor.config.assessContentType, this._getContentType())) {
+		if (this._isAssessment()) {
 			contentBody = this._removePluginStage(contentBody, 'org.ekstep.summary')
 		} 
 		this._loadMedia(contentBody)
@@ -536,6 +537,15 @@ org.ekstep.contenteditor.stageManager = new (Class.extend({
 		})
 		return summaryData
 	},
+
+	_isAssessment : function() {
+		return _.includes(_.mapValues(this._assessContentType(), _.method('toLowerCase')), _.toLower(this._getContentType()))
+	},
+
+	_assessContentType : function() {
+		return _.has(org.ekstep.contenteditor.config, 'assessContentType') ? org.ekstep.contenteditor.config.assessContentType : ['SelfAssess']; 
+	},
+
 	_getContentType: function () {
 		return ecEditor.getService('content').getContentMeta(org.ekstep.contenteditor.api.getContext('contentId')).contentType
 	},

--- a/test/scripts/CE-integration.spec.js
+++ b/test/scripts/CE-integration.spec.js
@@ -148,6 +148,12 @@ describe('content editor integration test: ', function () {
 
 		var stageECML
 
+		var themeObjectWithSummaryPlugin
+
+		var themeObjectWithoutSummaryPlugin
+
+		var summaryTemplate
+
 		beforeAll(function () {
 			stageECML = {
 				'config': {
@@ -165,6 +171,22 @@ describe('content editor integration test: ', function () {
 				'rotate': ''
 			}
 			stageInstance = org.ekstep.contenteditor.api.instantiatePlugin(stagePlugin, _.cloneDeep(stageECML))
+
+			themeObjectWithSummaryPlugin =  {'theme':{'compatibilityVersion':2,'id':'theme','manifest':{'media':[{'id':'org.ekstep.summary_template_js','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/renderer/summary-template.js','type':'js','ver':'1.0'},{'id':'org.ekstep.summary_template_css','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/renderer/style.css','type':'css','ver':'1.0'},{'id':'org.ekstep.summary','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/renderer/plugin.js','type':'plugin','ver':'1.0'},{'id':'org.ekstep.summary_manifest','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/manifest.json','type':'json','ver':'1.0'},{'assetId':'summaryImage','id':'summaryImage','preload':true,'src':'/content-plugins/org.ekstep.summary-1.0/assets/summary-icon.jpg','type':'image'}]},'plugin-manifest':{'depends':'','id':'org.ekstep.summary','type':'plugin','ver':'1.0'},'stage':{'config':{'__cdata':'{\'opacity\':100,\'strokeWidth\':1,\'stroke\':\'rgba(255, 255, 255, 0)\',\'autoplay\':false,\'visible\':true,\'color\':\'#FFFFFF\',\'genieControls\':false,\'instructions\':\'\'}'},'h':100,'id':'summary_stage_id','manifest':{'media':[{'assetId':'summaryImage'}]},'org.ekstep.summary':[{'config':{'__cdata':'{\'opacity\':100,\'strokeWidth\':1,\'stroke\':\'rgba(255, 255, 255, 0)\',\'autoplay\':false,\'visible\':true}'},'h':125.53,'id':'9aa63c0a-095a-4d67-991d-97c92b7e815a','rotate':0,'w':77.45,'x':6.69,'y':-27.9,'z-index':0}],'rotate':null,'w':100,'x':0,'y':0}}}
+			themeObjectWithoutSummaryPlugin = {"theme":{"compatibilityVersion":2,"id":"theme","manifest":{"media":[]},"plugin-manifest":{"depends":"","id":"org.ekstep.summary","type":"plugin","ver":"1.0","plugin":[]},"stage":[]}}
+			summaryTemplate = {'manifest':{'media':[{'id':'org.ekstep.summary_template_js','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/renderer/summary-template.js','type':'js','ver':'1.0'},{'id':'org.ekstep.summary_template_css','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/renderer/style.css','type':'css','ver':'1.0'},{'id':'org.ekstep.summary','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/renderer/plugin.js','type':'plugin','ver':'1.0'},{'id':'org.ekstep.summary_manifest','plugin':'org.ekstep.summary','src':'/content-plugins/org.ekstep.summary-1.0/manifest.json','type':'json','ver':'1.0'},{'assetId':'summaryImage','id':'org.ekstep.summary_summaryImage','preload':true,'src':'/content-plugins/org.ekstep.summary-1.0/assets/summary-icon.jpg','type':'image'}]},'pluginManifest':{'depends':'','id':'org.ekstep.summary','type':'plugin','ver':'1.0'},'stage':{'config':{'__cdata':'{\'opacity\':100,\'strokeWidth\':1,\'stroke\':\'rgba(255, 255, 255, 0)\',\'autoplay\':false,\'visible\':true,\'color\':\'#FFFFFF\',\'genieControls\':false,\'instructions\':\'\'}'},'h':100,'id':'summary_stage_id','manifest':{'media':[{'assetId':'summaryImage'}]},'org.ekstep.summary':[{'config':{'__cdata':'{\'opacity\':100,\'strokeWidth\':1,\'stroke\':\'rgba(255, 255, 255, 0)\',\'autoplay\':false,\'visible\':true}'},'h':125.53,'id':'9aa63c0a-095a-4d67-991d-97c92b7e815a','rotate':0,'w':77.45,'x':6.69,'y':-27.9,'z-index':0}],'rotate':null,'w':100,'x':0,'y':0}}
+		})
+
+		it('should add stage to theme', function () {
+			var noOfStages = themeObjectWithoutSummaryPlugin.theme.stage.length
+			var updatedThemeObj = org.ekstep.contenteditor.stageManager._appendPluginStage(themeObjectWithoutSummaryPlugin, summaryTemplate)
+			expect(updatedThemeObj.theme.stage.length).toBe(noOfStages + 1)
+			expect(updatedThemeObj.theme.stage[0]['org.ekstep.summary']).toBeDefined()
+		})
+
+		it('should remove stage from theme object', function () {
+			var updatedThemeObj = org.ekstep.contenteditor.stageManager._removePluginStage(themeObjectWithSummaryPlugin, 'org.ekstep.summary')
+			expect(updatedThemeObj.theme.stage[0]).not.toContain('org.ekstep.summary')
 		})
 
 		it('instance properties should be defined', function () {
@@ -273,6 +295,8 @@ describe('content editor integration test: ', function () {
 			org.ekstep.contenteditor.stageManager.addMediaToMediaMap({'plugin': {'type': 'plugin'}}, {'plugin': 'plugin'})
 			// expect(org.ekstep.contenteditor.stageManager.mergeMediaMap).toHaveBeenCalledTimes(1);
 		})
+
+		
 	})
 
 	describe('when test1 plugin instantiated', function () {


### PR DESCRIPTION
## Assessment End page handling in the content editor Scenario

### Scenario: If a user is creating self-assessment content using Editor
    Given User is coming from program portal dashboard by clicking on Assessment 

    When a user includes question set in editor stage and click on the preview or save
    Then add summary plugin stage programmatically as the last stage


### Scenario: If a user is editing self-assessment content using Editor
    Given User is coming from program portal by clicking on existing self-assessment content

    When a user opens any existing content in the content editor
    And self assess content has the summery plugin 
    Then remove the summary plugin stage and related media from manifest

    When a user clicks on the preview or save button
    Then add summary plugin stage programmatically as the last stage

### Scenario: If a user is creating or editing other than self-assessment content type
    Given User is coming from program portal dashboard by clicking on Resource

    When a user opens any existing content in the content editor
    Then open the content as it is

    When a user clicks on the preview or save button
    Then open existing preview without any modification 