### PR TITLE
Add Dependabot configuration and dependency submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+version: 2
+updates:
+  # Root package.json — main content editor source and build tooling
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+      gulp-tools:
+        patterns:
+          - "gulp*"
+          - "grunt*"
+      webpack-tools:
+        patterns:
+          - "webpack*"
+          - "*-loader"
+          - "clean-webpack-plugin"
+          - "copy-webpack-plugin"
+          - "mini-css-extract-plugin"
+          - "html-webpack-plugin"
+          - "zip-webpack-plugin"
+          - "compression-webpack-plugin"
+      karma-testing:
+        patterns:
+          - "karma*"
+          - "jasmine*"
+      eslint:
+        patterns:
+          - "eslint*"
+
+  # deploy/ has its own package.json with gulp deployment tooling
+  - package-ecosystem: "npm"
+    directory: "/deploy"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      gulp-tools:
+        patterns:
+          - "gulp*"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,50 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'deploy/package.json'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'deploy/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-npm-root:
+    name: Submit npm (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  submit-npm-deploy:
+    name: Submit npm (deploy/)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      # No lock file in deploy/ — generate one without installing node_modules
+      - run: npm install --package-lock-only
+        working-directory: deploy
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./deploy


### PR DESCRIPTION
Summary                                                

  - Enables Dependabot to automatically open weekly PRs for npm dependencies in / and /deploy, as well as GitHub Actions workflow versions, keeping the dependency graph and security 
  alerts up to date.
  - Adds a dependency-submission workflow that reports transitive npm dependency graphs to GitHub before Dependabot runs each Monday, ensuring Dependabot has complete visibility —   
  including the deploy/ package that has no committed lock file.                                                                                                                      
  - Dependencies are grouped by ecosystem (Sunbird packages, Gulp/Webpack tooling, Karma/Jasmine testing, ESLint) to reduce PR noise.
                                                                                                                                                                                      
  Changes                                                
                                                                                                                                                                                      
  - .github/dependabot.yml — Configures three Dependabot ecosystems: npm at /, npm at /deploy, and github-actions at /. Weekly schedule on Mondays at 03:30 UTC, with grouped update  
  rules to batch related packages together.
  - .github/workflows/dependency-submission.yml — Runs npm-dependency-submission-action for both the root and deploy/ packages. Triggers on schedule (Monday 03:00 UTC), on pushes/PRs
   to master that touch package*.json, and manually via workflow_dispatch. Generates a transient lock file for deploy/ since none is committed.                                       
  
  How to Test                                                                                                                                                                         
                                                         
  1. Merge this PR and navigate to the repository's Insights → Dependency graph tab — both package.json files should appear within ~10 minutes after the workflow runs.               
  2. Trigger the workflow manually: Actions → Dependency Submission → Run workflow and confirm it completes without errors.
  3. Wait until the next Monday or manually trigger a Dependabot run from Insights → Dependency graph → Dependabot to confirm PRs are opened with the correct labels and grouped      
  commits.                                                                                                                                                                            
  4. Verify that a chore(deps) PR is opened for npm packages and a chore(ci) PR is opened for any outdated GitHub Actions.                                                            
                                                                                                                                                                                      
  Checklist                                              
                                                                                                                                                                                      
  - Tests added or updated                                                                                                                                                            
  - Documentation updated (if public API or behavior changed)
  - No breaking changes — or breaking changes noted with ! in title and explained in Summary                                                                                          
  - Reviewed my own diff before requesting review                                                                                                                                     
                                                                                                                                                                                      
  ---